### PR TITLE
Refactor most builder logic to TestRailAPIAdapter

### DIFF
--- a/.github/workflows/python-package.yml
+++ b/.github/workflows/python-package.yml
@@ -31,7 +31,7 @@ jobs:
         python -m pip install -r requirements.txt -r dev-requirements.txt
     - name: Lint
       run: |
-        python -m pylint testrail_data_model
+        python -m pylint $(git ls-files '*.py' | grep -v 'tests/')
     - name: Test with pytest
       run: |
         coverage run -m pytest tests

--- a/README.md
+++ b/README.md
@@ -22,16 +22,20 @@ Example
 from testrail_api import TestRailAPI
 
 from testrail_data_model.builder import TestRailAPIObjectBuilder
-from testrail_data_model.model import TestRailSection, TestRailCase
+from testrail_data_model.adapter import TestRailAPIAdapter
+from testrail_data_model.model import TestRailSection, TestRailCase, TestRailSuite
 
 # From testrail-api client library
-api = TestRailAPI(url="https://testrail-instance.com", email="email@email.org", password="password")
+api_client = TestRailAPI(url="https://testrail-instance.com", email="email@email.org", password="password")
 
-# For building the TestRail dataclass object instances
-builder = TestRailAPIObjectBuilder(api_client=api)
+# Performs API requests and tracks stats
+adapter = TestRailAPIAdapter(api_client=api_client)
+
+# For building the TestRail dataclass object hierarchies (e.g. TestRailSuite)
+builder = TestRailAPIObjectBuilder(adapter=adapter)
 
 # Construct a TestRailSuite object linked to its associated TestRailSection and TestRailCase objects
-suite = builder.build_suite(project_id=1, suite_id=1)
+suite: TestRailSuite = builder.build_suite(project_id=1, suite_id=1)
 
 # Display the TestRailSuite object structure
 for section_id, section in suite.sections.items():
@@ -42,7 +46,7 @@ for section_id, section in suite.sections.items():
        print("Case", case_id, case.title)
 
 # Show the number of API requests made
-print(builder.stats)
+print(adapter.stats)
 ```
 
 Authors

--- a/setup.py
+++ b/setup.py
@@ -1,5 +1,5 @@
 """
-Module to track stats about interactions with the TestRail API
+setup.py for testrail-data-model
 
 Copyright 2022 SiriusXM-Pandora
 
@@ -15,10 +15,8 @@ WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 See the License for the specific language governing permissions and
 limitations under the License.
 """
-
-from setuptools import setup, find_packages
-
 from pathlib import Path
+from setuptools import setup, find_packages
 
 from pbr.packaging import (
     get_version,
@@ -30,12 +28,12 @@ readme = Path(".", "README.md").absolute()
 with readme.open("r", encoding="utf-8") as file:
     long_description = file.read()
 
-package_name = 'testrail-data-model'
+PACKAGE_NAME = 'testrail-data-model'
 pkgs = find_packages(exclude=["tests"])
-version = get_version(package_name=package_name)
+version = get_version(package_name=PACKAGE_NAME)
 
 setup(
-    name=package_name,
+    name=PACKAGE_NAME,
     author="Elliot Weiser",
     author_email="elliot.weiser@gmail.com",
     packages=pkgs,
@@ -68,5 +66,4 @@ setup(
     long_description=long_description,
     long_description_content_type="text/markdown",
     url="https://github.com/PandoraMedia/testrail-data-model"
-
 )

--- a/testrail_data_model/adapter.py
+++ b/testrail_data_model/adapter.py
@@ -1,0 +1,358 @@
+"""
+Module providing an adapter class for interacting with the TestRail API
+
+Copyright 2022 SiriusXM-Pandora
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+"""
+
+from typing import List, Generator, Optional, Dict
+
+from testrail_api import TestRailAPI
+
+from testrail_data_model.model import (
+    TestRailProject,
+    TestRailSuite,
+    TestRailSection,
+    TestRailCase,
+    TestRailCaseField,
+    TestRailCaseType
+)
+from testrail_data_model.stats import TestRailAPIRequestStats
+
+
+class TestRailAPIAdapter:
+    """
+    A class for providing Python object representations of TestRail objects
+
+    Use this class in conjunction with TestRailProjectHierarchy to create
+    a TestRailProject linked to TestRailSuites, TestRailSections, and TestRailCases
+
+    :param api_client: client API for interacting with TestRail
+    :type api_client: TestRailAPI
+    :param stats: Used to track TestRail API metrics
+    :type stats: Optional[TestRailAPIRequestStats]
+    """
+
+    def __init__(self, api_client: TestRailAPI, stats: Optional[TestRailAPIRequestStats] = None):
+        """Constructor"""
+        self._api_client = api_client
+        self._stats = stats or TestRailAPIRequestStats()
+
+    @property
+    def api_client(self) -> TestRailAPI:
+        """
+        :return: Object for interacting with the TestRail API
+        :rtype: TestRailAPI
+        """
+        return self._api_client
+
+    @property
+    def stats(self) -> TestRailAPIRequestStats:
+        """
+        :return: Object tracking TestRail API request metrics
+        :rtype: TestRailAPIRequestStats
+        """
+        return self._stats
+
+    def get_project(self, project_id: int) -> TestRailProject:
+        """
+        Reference: https://www.gurock.com/testrail/docs/api/reference/projects/#getproject
+
+        :param project_id: the ID of the project data to retrieve
+        :type project_id: int
+        :rtype: TestRailProject
+        """
+        self.stats.get_project += 1
+        response: Dict = self.api_client.projects.get_project(project_id=project_id)
+        result = TestRailProject.from_data(response)
+        return result
+
+    def get_projects(self, is_completed: Optional[bool] = None, limit: int = 250, offset: int = 0)\
+            -> Generator[TestRailProject, None, None]:
+        """
+        Reference: https://www.gurock.com/testrail/docs/api/reference/projects/#getprojects
+
+        :param is_completed: True filters only completed, False for not-completed, None for no filtering
+        :type is_completed: bool, optional (default: None)
+        :param limit: return up to this many projects, default 250
+        :type limit: int
+        :param offset: skip this many projects before returning up to 'limit' projects, default 0
+        :type offset: int
+        :return: yields TestRailProject instances
+        :rtype: Generator[TestRailProject, None, None]
+        """
+        kwargs = {} if is_completed is None else {'is_completed': int(is_completed)}
+        while True:
+            self.stats.get_projects += 1
+            response = self.api_client.projects.get_projects(limit=limit, offset=offset, **kwargs)
+            for item in response:
+                yield TestRailProject.from_data(item)
+            offset += len(response)
+            if len(response) < limit:
+                break
+
+    def get_suite(self, suite_id: int) -> TestRailSuite:
+        """
+        Reference: https://www.gurock.com/testrail/docs/api/reference/suites/#getsuite
+
+        :param suite_id: the ID of the suite data to retrieve
+        :type suite_id: int
+        :rtype: TestRailSuite
+        """
+        self.stats.get_suite += 1
+        response: Dict = self.api_client.suites.get_suite(suite_id=suite_id)
+        return TestRailSuite.from_data(response)
+
+    def get_suites(self, project_id: int) -> List[TestRailSuite]:
+        """
+        Reference: https://www.gurock.com/testrail/docs/api/reference/suites/#getsuites
+
+        :param project_id: the ID of the project from which to retrieve suite data
+        :type project_id: int
+        :rtype: List[TestRailSuite]
+        """
+        self.stats.get_suites += 1
+        response: List[Dict] = self.api_client.suites.get_suites(project_id=project_id)
+        return [TestRailSuite.from_data(item) for item in response]
+
+    def get_section(self, section_id: int) -> TestRailSection:
+        """
+        Reference: https://www.gurock.com/testrail/docs/api/reference/sections/#getsection
+
+        :param section_id: the ID of the section data to retrieve
+        :type section_id: int
+        :rtype: TestRailSection
+        """
+        self.stats.get_section += 1
+        response: Dict = self.api_client.sections.get_section(section_id=section_id)
+        return TestRailSection.from_data(response)
+
+    def get_sections(self, project_id: int, suite_id: Optional[int] = None, limit: int = 250, offset: int = 0)\
+            -> Generator[TestRailSection, None, None]:
+        """
+        Reference: https://www.gurock.com/testrail/docs/api/reference/sections/#getsections
+
+        NOTE: This is a generator function which will retrieve section data
+        from the server in batches. If maximum limit is 250 and the suite
+        has 300 sections, this method will make 2 API requests, but since
+        it is a generator it will only issue the requests as needed,
+        i.e. when a for-loop requests the next item, but the previous batch
+        has been exhausted.
+
+        :param project_id: ID of the project from which to retrieve section data
+        :type project_id: int
+        :param suite_id: ID of suite (required if MULTIPLE_SUITES), default None
+        :type suite_id: Optional[int]
+        :param limit: return up to this many sections, default 250
+        :type limit: int
+        :param offset: skip this many sections before returning up to 'limit' sections, default 0
+        :type offset: int
+        :rtype: Generator[TestRailSection, None, None]
+        """
+        kwargs = {} if suite_id is None else {'suite_id': suite_id}
+        while True:
+            self.stats.get_sections += 1
+            response = self.api_client.sections.get_sections(project_id=project_id, limit=limit, offset=offset,
+                                                             **kwargs)
+            for item in response:
+                yield TestRailSection.from_data(item)
+            offset += len(response)
+            if len(response) < limit:
+                break
+
+    def add_section(self, project_id: int, name: str, suite_id: Optional[int] = None, parent_id: Optional[int] = None,
+                    description: Optional[str] = None) -> TestRailSection:
+        """
+        Reference: https://www.gurock.com/testrail/docs/api/reference/sections/#addsection
+
+        :param project_id: ID of the project to which to add the new section
+        :type project_id: int
+        :param name: the name of the new section
+        :type name: str
+        :param suite_id: ID of the suite (required if MULTIPLE_SUITES), default None
+        :type suite_id: Optional[int]
+        :param parent_id: ID of the parent section to associate to the new section, default None
+        :type parent_id: Optional[int]
+        :param description: description of the new section, default None
+        :type description: Optional[str]
+        :return: A new TestRailSection instance
+        :rtype: TestRailSection
+        """
+        self.stats.add_section += 1
+        response: Dict = self.api_client.sections.add_section(project_id=project_id, name=name, suite_id=suite_id,
+                                                              parent_id=parent_id, description=description)
+        return TestRailSection.from_data(response)
+
+    def move_section(self, section: TestRailSection, new_parent: Optional[TestRailSection] = None):
+        """
+        Reference: https://www.gurock.com/testrail/docs/api/reference/sections/#movesection
+
+        :param section: the section to move
+        :type section: TestRailSection
+        :param new_parent: the new parent of the moved section (default: None)
+        :type new_parent: Optional[TestRailSection]
+        """
+        parent_id = new_parent.section_id if new_parent is not None else None
+        self.stats.move_section += 1
+        self.api_client.sections.move_section(
+            section_id=section.section_id,
+            parent_id=parent_id
+        )
+        section.move(new_parent=new_parent)
+
+    def delete_section(self, section: TestRailSection, soft: bool = False):
+        """
+        Reference: https://www.gurock.com/testrail/docs/api/reference/sections/#deletesection
+
+        :param section: the section to delete
+        :type section: TestRailSection
+        :param soft: Insert "soft=1" in the API request to delete the section if True (default: False)
+        :type soft: bool
+        """
+        self.stats.delete_section += 1
+        self.api_client.sections.delete_section(section_id=section.section_id, soft=int(soft))
+        if not soft:
+            section.unlink()
+
+    def get_case(self, case_id: int) -> TestRailCase:
+        """
+        Reference: https://www.gurock.com/testrail/docs/api/reference/cases/#getcase
+
+        :param case_id: ID of the case whose data to retrieve
+        :type case_id: int
+        :rtype: TestRailCase
+        """
+        self.stats.get_case += 1
+        response: Dict = self.api_client.cases.get_case(case_id=case_id)
+        return TestRailCase.from_data(response)
+
+    def add_case(self, section_id: int, title: str, **kwargs) -> TestRailCase:
+        """
+        Reference: https://www.gurock.com/testrail/docs/api/reference/cases/#addcase
+
+        :param section_id: the section ID to which the new case will be associated
+        :type section_id: int
+        :param title: title to set for the new case
+        :type title: str
+        :param kwargs: the fields to pass into the add_case API call
+        :type kwargs: Dict
+        :rtype: TestRailCase
+        """
+        self.stats.add_case += 1
+        response: Dict = self.api_client.cases.add_case(section_id=section_id, title=title, **kwargs)
+        return TestRailCase.from_data(response)
+
+    def update_case(self, case: TestRailCase, **kwargs):
+        """
+        Reference: https://www.gurock.com/testrail/docs/api/reference/cases/#updatecase
+
+        :param case: the case instance to update
+        :type case: TestRailCase
+        :param kwargs: fields to pass into the update_case API call
+        :type kwargs: Dict
+        :return: an updated TestRailCase instance
+        :rtype: TestRailCase
+        """
+        self.stats.update_case += 1
+        response: Dict = self.api_client.cases.update_case(case_id=case.case_id, **kwargs)
+        return TestRailCase.from_data(response)
+
+    def get_cases(self, project_id: int, suite_id: Optional[int] = None, limit: int = 250, offset: int = 0, **kwargs)\
+            -> Generator[TestRailCase, None, None]:
+        """
+        https://www.gurock.com/testrail/docs/api/reference/cases/#getcases
+
+        NOTE: This is a generator function which will retrieve case data
+        from the server in batches. If maximum limit is 250 and the suite
+        has 900 cases, this method will make 4 API requests, but since
+        it is a generator it will only issue the requests as needed,
+        i.e. when a for-loop requests the next item, but the previous batch
+        has been exhausted.
+
+        :param project_id: ID of project
+        :type project_id: int,
+        :param suite_id: ID of suite (required if MULTIPLE_SUITES), default None
+        :type suite_id: Optional[int]
+        :param limit: return up to this many cases, default 250
+        :type limit: int
+        :param offset: skip this many cases before returning up to 'limit' cases, default 0
+        :type offset: int
+        :rtype: Generator[TestRailCase, None, None]
+        """
+        if suite_id is not None:
+            kwargs.update({'suite_id': suite_id})
+        while True:
+            self.stats.get_cases += 1
+            response = self.api_client.cases.get_cases(project_id=project_id, limit=limit, offset=offset, **kwargs)
+            for item in response:
+                yield TestRailCase.from_data(item)
+            offset += len(response)
+            if len(response) < limit:
+                break
+
+    def delete_case(self, case: TestRailCase, soft: bool = False):
+        """
+        Reference: https://www.gurock.com/testrail/docs/api/reference/cases/#deletecase
+
+        :param case: the case to delete
+        :type case: TestRailCase
+        :param soft: Insert "soft=1" in the API request to delete the case if True (default: False)
+        :type soft: bool
+        """
+        self.stats.delete_case += 1
+        self.api_client.cases.delete_case(case_id=case.case_id, soft=int(soft))
+        if not soft:
+            case.unlink()
+
+    def get_case_fields(self) -> List[TestRailCaseField]:
+        """
+        https://www.gurock.com/testrail/docs/api/reference/case-fields/#getcasefields
+
+        :return: List[TestRailCaseField]
+        """
+        self.stats.get_case_fields += 1
+        response: List[Dict] = self.api_client.case_fields.get_case_fields()
+        return [TestRailCaseField.from_data(item) for item in response]
+
+    def get_case_types(self) -> List[TestRailCaseType]:
+        """
+        :return: list of TestRailCaseType objects from the TestRail API
+        :rtype: List[TestRailCaseType]
+        """
+        self.stats.get_case_types += 1
+        response: List[Dict] = self.api_client.case_types.get_case_types()
+        return [TestRailCaseType.from_data(item) for item in response]
+
+    def create_new_section_for_path(self, suite: TestRailSuite, path: str) -> TestRailSection:
+        """
+        :param suite: TestRailSuite, the suite in which to create the section
+        :type suite: TestRailSuite
+        :param path: The intended path for the new section
+        :type path: str
+        :return: TestRailSection linked to an appropriate parent TestRailSection
+        :rtype: TestRailSection
+        """
+        split_paths = path.rsplit('/', maxsplit=1)
+        name = split_paths[-1]
+        parent_path = None if len(split_paths) == 1 else split_paths[0]
+        parent = None if parent_path is None else suite.section_for_path(parent_path)
+        parent_id = None if parent is None else parent.section_id
+        new_section = self.add_section(
+            project_id=suite.project_id,
+            name=name,
+            suite_id=suite.suite_id,
+            parent_id=parent_id
+        )
+        new_section.link(suite=suite, parent=parent)
+        return new_section

--- a/testrail_data_model/builder.py
+++ b/testrail_data_model/builder.py
@@ -16,278 +16,21 @@ See the License for the specific language governing permissions and
 limitations under the License.
 """
 
-from typing import List, Generator, Optional, Dict
-
-from testrail_api import TestRailAPI
-
-from .model import (
-    TestRailProject,
-    TestRailSuite,
-    TestRailSection,
-    TestRailCase,
-    TestRailCaseField,
-    TestRailCaseType
-)
-from .stats import TestRailAPIRequestStats
+from .adapter import TestRailAPIAdapter
+from .model import TestRailSuite
 
 
-class TestRailAPIObjectBuilder:
+class TestRailAPIObjectBuilder:  # pylint: disable=too-few-public-methods
     """
-    A class for providing Python object representations of TestRail objects
+    A builder class for linked TestRail object hierarchies, e.g. TestRailSuite
 
-    Use this class in conjunction with TestRailProjectHierarchy to create
-    a TestRailProject linked to TestRailSuites, TestRailSections, and TestRailCases
-
-    :param api_client: client API for interacting with TestRail
-    :type api_client: TestRailAPI
-    :param stats: Used to track TestRail API metrics
-    :type stats: Optional[TestRailAPIRequestStats]
+    :param adapter: object wrapping TestRailAPI and tracking request stats
+    :type adapter: TestRailAPIAdapter
     """
 
-    def __init__(self, api_client: TestRailAPI, stats: Optional[TestRailAPIRequestStats] = None):
+    def __init__(self, adapter: TestRailAPIAdapter):
         """Constructor"""
-        self._api_client = api_client
-        self._stats = stats or TestRailAPIRequestStats()
-
-    @property
-    def api_client(self) -> TestRailAPI:
-        """
-        :return: Object for interacting with the TestRail API
-        :rtype: TestRailAPI
-        """
-        return self._api_client
-
-    @property
-    def stats(self) -> TestRailAPIRequestStats:
-        """
-        :return: Object tracking TestRail API request metrics
-        :rtype: TestRailAPIRequestStats
-        """
-        return self._stats
-
-    def get_project(self, project_id: int) -> TestRailProject:
-        """
-        Reference: https://www.gurock.com/testrail/docs/api/reference/projects/#getproject
-
-        :param project_id: the ID of the project data to retrieve
-        :type project_id: int
-        :rtype: TestRailProject
-        """
-        self.stats.get_project += 1
-        response: Dict = self.api_client.projects.get_project(project_id=project_id)
-        result = TestRailProject.from_data(response)
-        return result
-
-    def get_projects(self, is_completed: Optional[bool] = None, limit: int = 250, offset: int = 0)\
-            -> Generator[TestRailProject, None, None]:
-        """
-        Reference: https://www.gurock.com/testrail/docs/api/reference/projects/#getprojects
-
-        :param is_completed: True filters only completed, False for not-completed, None for no filtering
-        :type is_completed: bool, optional (default: None)
-        :param limit: return up to this many projects, default 250
-        :type limit: int
-        :param offset: skip this many projects before returning up to 'limit' projects, default 0
-        :type offset: int
-        :return: yields TestRailProject instances
-        :rtype: Generator[TestRailProject, None, None]
-        """
-        kwargs = {} if is_completed is None else {'is_completed': int(is_completed)}
-        while True:
-            self.stats.get_projects += 1
-            response = self.api_client.projects.get_projects(limit=limit, offset=offset, **kwargs)
-            for item in response:
-                yield TestRailProject.from_data(item)
-            offset += len(response)
-            if len(response) < limit:
-                break
-
-    def get_suite(self, suite_id: int) -> TestRailSuite:
-        """
-        Reference: https://www.gurock.com/testrail/docs/api/reference/suites/#getsuite
-
-        :param suite_id: the ID of the suite data to retrieve
-        :type suite_id: int
-        :rtype: TestRailSuite
-        """
-        self.stats.get_suite += 1
-        response: Dict = self.api_client.suites.get_suite(suite_id=suite_id)
-        return TestRailSuite.from_data(response)
-
-    def get_suites(self, project_id: int) -> List[TestRailSuite]:
-        """
-        Reference: https://www.gurock.com/testrail/docs/api/reference/suites/#getsuites
-
-        :param project_id: the ID of the project from which to retrieve suite data
-        :type project_id: int
-        :rtype: List[TestRailSuite]
-        """
-        self.stats.get_suites += 1
-        response: List[Dict] = self.api_client.suites.get_suites(project_id=project_id)
-        return [TestRailSuite.from_data(item) for item in response]
-
-    def get_section(self, section_id: int) -> TestRailSection:
-        """
-        Reference: https://www.gurock.com/testrail/docs/api/reference/sections/#getsection
-
-        :param section_id: the ID of the section data to retrieve
-        :type section_id: int
-        :rtype: TestRailSection
-        """
-        self.stats.get_section += 1
-        response: Dict = self.api_client.sections.get_section(section_id=section_id)
-        return TestRailSection.from_data(response)
-
-    def get_sections(self, project_id: int, suite_id: Optional[int] = None, limit: int = 250, offset: int = 0)\
-            -> Generator[TestRailSection, None, None]:
-        """
-        Reference: https://www.gurock.com/testrail/docs/api/reference/sections/#getsections
-
-        NOTE: This is a generator function which will retrieve section data
-        from the server in batches. If maximum limit is 250 and the suite
-        has 300 sections, this method will make 2 API requests, but since
-        it is a generator it will only issue the requests as needed,
-        i.e. when a for-loop requests the next item, but the previous batch
-        has been exhausted.
-
-        :param project_id: ID of the project from which to retrieve section data
-        :type project_id: int
-        :param suite_id: ID of suite (required if MULTIPLE_SUITES), default None
-        :type suite_id: Optional[int]
-        :param limit: return up to this many sections, default 250
-        :type limit: int
-        :param offset: skip this many sections before returning up to 'limit' sections, default 0
-        :type offset: int
-        :rtype: Generator[TestRailSection, None, None]
-        """
-        kwargs = {} if suite_id is None else {'suite_id': suite_id}
-        while True:
-            self.stats.get_sections += 1
-            response = self.api_client.sections.get_sections(project_id=project_id, limit=limit, offset=offset,
-                                                              **kwargs)
-            for item in response:
-                yield TestRailSection.from_data(item)
-            offset += len(response)
-            if len(response) < limit:
-                break
-
-    def add_section(self, project_id: int, name: str, suite_id: Optional[int] = None, parent_id: Optional[int] = None,
-                    description: Optional[str] = None) -> TestRailSection:
-        """
-        Reference: https://www.gurock.com/testrail/docs/api/reference/sections/#addsection
-
-        :param project_id: ID of the project to which to add the new section
-        :type project_id: int
-        :param name: the name of the new section
-        :type name: str
-        :param suite_id: ID of the suite (required if MULTIPLE_SUITES), default None
-        :type suite_id: Optional[int]
-        :param parent_id: ID of the parent section to associate to the new section, default None
-        :type parent_id: Optional[int]
-        :param description: description of the new section, default None
-        :type description: Optional[str]
-        :return: A new TestRailSection instance
-        :rtype: TestRailSection
-        """
-        self.stats.add_section += 1
-        response: Dict = self.api_client.sections.add_section(project_id=project_id, name=name, suite_id=suite_id,
-                                                               parent_id=parent_id, description=description)
-        return TestRailSection.from_data(response)
-
-    def get_case(self, case_id: int) -> TestRailCase:
-        """
-        Reference: https://www.gurock.com/testrail/docs/api/reference/cases/#getcase
-
-        :param case_id: ID of the case whose data to retrieve
-        :type case_id: int
-        :rtype: TestRailCase
-        """
-        self.stats.get_case += 1
-        response: Dict = self.api_client.cases.get_case(case_id=case_id)
-        return TestRailCase.from_data(response)
-
-    def add_case(self, section_id: int, title: str, **kwargs) -> TestRailCase:
-        """
-        Reference: https://www.gurock.com/testrail/docs/api/reference/cases/#addcase
-
-        :param section_id: the section ID to which the new case will be associated
-        :type section_id: int
-        :param title: title to set for the new case
-        :type title: str
-        :param kwargs: the fields to pass into the add_case API call
-        :type kwargs: Dict
-        :rtype: TestRailCase
-        """
-        self.stats.add_case += 1
-        response: Dict = self.api_client.cases.add_case(section_id=section_id, title=title, **kwargs)
-        return TestRailCase.from_data(response)
-
-    def update_case(self, case: TestRailCase, **kwargs):
-        """
-        Reference: https://www.gurock.com/testrail/docs/api/reference/cases/#updatecase
-
-        :param case: the case instance to update
-        :type case: TestRailCase
-        :param kwargs: fields to pass into the update_case API call
-        :type kwargs: Dict
-        :return: an updated TestRailCase instance
-        :rtype: TestRailCase
-        """
-        self.stats.update_case += 1
-        response: Dict = self.api_client.cases.update_case(case_id=case.case_id, **kwargs)
-        return TestRailCase.from_data(response)
-
-    def get_cases(self, project_id: int, suite_id: Optional[int] = None, limit: int = 250, offset: int = 0, **kwargs)\
-            -> Generator[TestRailCase, None, None]:
-        """
-        https://www.gurock.com/testrail/docs/api/reference/cases/#getcases
-
-        NOTE: This is a generator function which will retrieve case data
-        from the server in batches. If maximum limit is 250 and the suite
-        has 900 cases, this method will make 4 API requests, but since
-        it is a generator it will only issue the requests as needed,
-        i.e. when a for-loop requests the next item, but the previous batch
-        has been exhausted.
-
-        :param project_id: ID of project
-        :type project_id: int,
-        :param suite_id: ID of suite (required if MULTIPLE_SUITES), default None
-        :type suite_id: Optional[int]
-        :param limit: return up to this many cases, default 250
-        :type limit: int
-        :param offset: skip this many cases before returning up to 'limit' cases, default 0
-        :type offset: int
-        :rtype: Generator[TestRailCase, None, None]
-        """
-        if suite_id is not None:
-            kwargs.update({'suite_id': suite_id})
-        while True:
-            self.stats.get_cases += 1
-            response = self.api_client.cases.get_cases(project_id=project_id, limit=limit, offset=offset, **kwargs)
-            for item in response:
-                yield TestRailCase.from_data(item)
-            offset += len(response)
-            if len(response) < limit:
-                break
-
-    def get_case_fields(self) -> List[TestRailCaseField]:
-        """
-        https://www.gurock.com/testrail/docs/api/reference/case-fields/#getcasefields
-
-        :return: List[TestRailCaseField]
-        """
-        self.stats.get_case_fields += 1
-        response: List[Dict] = self.api_client.case_fields.get_case_fields()
-        return [TestRailCaseField.from_data(item) for item in response]
-
-    def get_case_types(self) -> List[TestRailCaseType]:
-        """
-        :return: list of TestRailCaseType objects from the TestRail API
-        :rtype: List[TestRailCaseType]
-        """
-        self.stats.get_case_types += 1
-        response: List[Dict] = self.api_client.case_types.get_case_types()
-        return [TestRailCaseType.from_data(item) for item in response]
+        self._adapter = adapter
 
     def build_suite(self, project_id: int, suite_id: int) -> TestRailSuite:
         """
@@ -295,11 +38,16 @@ class TestRailAPIObjectBuilder:
         all associated TestRailSection and TestRailCase objects loaded and linked
         together.
 
-        :return: TestRailSuite
+        :param project_id: TestRail Project ID
+        :type project_id: int
+        :param suite_id: TestRail Suite ID
+        :type suite_id: int
+        :return: A TestRailSuite object linked to associated TestRailSection and TestRailCase objects
+        :rtype: TestRailSuite
         """
-        suite: TestRailSuite = self.get_suite(suite_id=suite_id)
-        sections = self.get_sections(project_id=project_id, suite_id=suite_id)
-        cases = self.get_cases(project_id=project_id, suite_id=suite_id)
+        suite: TestRailSuite = self._adapter.get_suite(suite_id=suite_id)
+        sections = self._adapter.get_sections(project_id=project_id, suite_id=suite_id)
+        cases = self._adapter.get_cases(project_id=project_id, suite_id=suite_id)
         section_dict = {section.section_id: section for section in sections}
         case_dict = {case.case_id: case for case in cases}
 
@@ -316,26 +64,3 @@ class TestRailAPIObjectBuilder:
             section = section_dict.get(case.section_id, None)
             case.link(suite=suite, section=section)
         return suite
-
-    def create_new_section_for_path(self, suite: TestRailSuite, path: str) -> TestRailSection:
-        """
-        :param suite: TestRailSuite, the suite in which to create the section
-        :type suite: TestRailSuite
-        :param path: The intended path for the new section
-        :type path: str
-        :return: TestRailSection linked to an appropriate parent TestRailSection
-        :rtype: TestRailSection
-        """
-        split_paths = path.rsplit('/', maxsplit=1)
-        name = split_paths[-1]
-        parent_path = None if len(split_paths) == 1 else split_paths[0]
-        parent = None if parent_path is None else suite.section_for_path(parent_path)
-        parent_id = None if parent is None else parent.section_id
-        new_section = self.add_section(
-            project_id=suite.project_id,
-            name=name,
-            suite_id=suite.suite_id,
-            parent_id=parent_id
-        )
-        new_section.link(suite=suite, parent=parent)
-        return new_section

--- a/tests/test_adapter.py
+++ b/tests/test_adapter.py
@@ -1,0 +1,271 @@
+from typing import Generator
+
+from .conftest import *
+
+
+@pytest.fixture()
+def subject_adapter(mock_api_client, stats_fixture):
+    subject = TestRailAPIAdapter(api_client=mock_api_client, stats=stats_fixture)
+    return subject
+
+
+def test_get_project_returns_correct_instance_type(subject_adapter, mock_api_client):
+    project_id = FIELD("integer_number", start=1, end=1000)
+    actual = subject_adapter.get_project(project_id=project_id)
+    mock_api_client.projects.get_project.assert_called_once_with(project_id=project_id)
+    assert isinstance(actual, TestRailProject)
+    assert actual.announcement is not None
+    assert subject_adapter.stats.get_project == 1
+    assert subject_adapter.stats.total == 1
+
+
+def test_get_projects_returns_generator_of_project_instances(subject_adapter, mock_api_client):
+    actual = subject_adapter.get_projects(limit=1)
+    assert isinstance(actual, Generator)
+    for project in actual:
+        assert isinstance(project, TestRailProject)
+        assert project.announcement is not None
+    expected_calls = [call(limit=1, offset=i) for i in range(4)]
+    mock_api_client.projects.get_projects.assert_has_calls(calls=expected_calls, any_order=False)
+    assert subject_adapter.stats.get_projects == 4
+    assert subject_adapter.stats.total == 4
+
+
+def test_get_suite_returns_correct_instance_type(subject_adapter, mock_api_client):
+    suite_id = FIELD("integer_number", start=1, end=1000)
+    actual = subject_adapter.get_suite(suite_id=suite_id)
+    mock_api_client.suites.get_suite.assert_called_once_with(suite_id=suite_id)
+    assert isinstance(actual, TestRailSuite)
+    assert actual.description is not None
+    assert subject_adapter.stats.get_suite == 1
+    assert subject_adapter.stats.total == 1
+
+
+def test_get_suites_returns_list_of_suite_instances(subject_adapter, mock_api_client):
+    project_id = FIELD("integer_number", start=1, end=1000)
+    actual = subject_adapter.get_suites(project_id=project_id)
+    assert len(actual) > 0
+    for suite in actual:
+        assert isinstance(suite, TestRailSuite)
+        assert suite.description is not None
+    mock_api_client.suites.get_suites.assert_called_once_with(project_id=project_id)
+    assert subject_adapter.stats.get_suites == 1
+    assert subject_adapter.stats.total == 1
+
+
+def test_get_sections_returns_correct_instance_type(subject_adapter, mock_api_client):
+    section_id = FIELD("integer_number", start=1, end=1000)
+    actual = subject_adapter.get_section(section_id=section_id)
+    mock_api_client.sections.get_section.assert_called_once_with(section_id=section_id)
+    assert isinstance(actual, TestRailSection)
+    assert actual.description is not None
+    assert subject_adapter.stats.get_section == 1
+    assert subject_adapter.stats.total == 1
+
+
+def test_get_section_returns_generator_of_sections(subject_adapter, mock_api_client):
+    project_id = FIELD("integer_number", start=1, end=1000)
+    suite_id = FIELD("integer_number", start=1, end=1000)
+    actual = subject_adapter.get_sections(project_id=project_id, suite_id=suite_id, limit=1, offset=0)
+    for section in actual:
+        assert isinstance(section, TestRailSection)
+        assert section.description is not None
+    expected_calls = [call(limit=1, offset=i, project_id=project_id, suite_id=suite_id) for i in range(4)]
+    mock_api_client.sections.get_sections.assert_has_calls(calls=expected_calls, any_order=False)
+    assert subject_adapter.stats.total == 4
+    assert subject_adapter.stats.get_sections == 4
+
+
+def test_add_section_returns_correct_instance_type(subject_adapter, mock_api_client):
+    project_id = FIELD("integer_number", start=1, end=1000)
+    suite_id = FIELD("integer_number", start=1, end=1000)
+    name = FIELD("word")
+    description = FIELD("text")
+    parent_id = FIELD("integer_number", start=1, end=1000)
+    actual = subject_adapter.add_section(
+        project_id=project_id,
+        suite_id=suite_id,
+        name=name,
+        description=description,
+        parent_id=parent_id
+    )
+    mock_api_client.sections.add_section.assert_called_once_with(
+        project_id=project_id,
+        suite_id=suite_id,
+        name=name,
+        description=description,
+        parent_id=parent_id
+    )
+    assert isinstance(actual, TestRailSection)
+    assert actual.description is not None
+    assert subject_adapter.stats.add_section == 1
+    assert subject_adapter.stats.total == 1
+
+
+def test_get_case_returns_correct_instance_type(subject_adapter, mock_api_client):
+    case_id = FIELD("integer_number", start=1, end=1000)
+    actual = subject_adapter.get_case(case_id=case_id)
+    assert isinstance(actual, TestRailCase)
+    assert len(actual.steps_separated) == 1
+    assert actual.steps_separated[0]["content"] is not None
+    assert subject_adapter.stats.get_case == 1
+    assert subject_adapter.stats.total == 1
+    mock_api_client.cases.get_case.assert_called_once_with(case_id=case_id)
+
+
+def test_add_case_returns_correct_instance_type(subject_adapter, mock_api_client):
+    section_id = FIELD("integer_number", start=1, end=1000)
+    title = FIELD("title")
+    actual = subject_adapter.add_case(section_id=section_id, title=title)
+    assert isinstance(actual, TestRailCase)
+    assert len(actual.steps_separated) == 1
+    assert actual.steps_separated[0]["content"] is not None
+    assert subject_adapter.stats.add_case == 1
+    assert subject_adapter.stats.total == 1
+    mock_api_client.cases.add_case.assert_called_once_with(section_id=section_id, title=title)
+
+
+def test_update_case_returns_correct_instance_type(subject_adapter, mock_api_client):
+    case_id = FIELD("integer_number", start=1, end=1000)
+    section_id = FIELD("integer_number", start=1, end=1000)
+    title = FIELD("title")
+    start_case = subject_adapter.get_case(case_id=case_id)
+    actual = subject_adapter.update_case(case=start_case, title=title, section_id=section_id)
+    assert isinstance(actual, TestRailCase)
+    assert len(actual.steps_separated) == 1
+    assert actual.steps_separated[0]["content"] is not None
+    assert subject_adapter.stats.update_case == 1
+    assert subject_adapter.stats.total == 2
+    mock_api_client.cases.update_case.assert_called_once_with(
+        case_id=start_case.case_id,
+        title=title,
+        section_id=section_id
+    )
+
+
+def test_get_cases_returns_generator_of_cases(subject_adapter, mock_api_client):
+    project_id = FIELD("integer_number", start=1, end=1000)
+    actual = subject_adapter.get_cases(project_id=project_id, limit=2, offset=0)
+    assert isinstance(actual, Generator)
+    for case in actual:
+        assert isinstance(case, TestRailCase)
+        assert len(case.steps_separated) == 1
+        assert case.steps_separated[0]["content"] is not None
+    expected_calls = [call(project_id=project_id, limit=2, offset=i) for i in range(0, 4, 2)]
+    mock_api_client.cases.get_cases.assert_has_calls(expected_calls, any_order=False)
+    assert subject_adapter.stats.get_cases == 2
+    assert subject_adapter.stats.total == 2
+
+
+def test_get_cases_with_suite_returns_generator_of_cases(subject_adapter, mock_api_client):
+    project_id = FIELD("integer_number", start=1, end=1000)
+    suite_id = FIELD("integer_number", start=1, end=1000)
+    actual = subject_adapter.get_cases(project_id=project_id, suite_id=suite_id, limit=2, offset=0)
+    assert isinstance(actual, Generator)
+    for case in actual:
+        assert isinstance(case, TestRailCase)
+        assert len(case.steps_separated) == 1
+        assert case.steps_separated[0]["content"] is not None
+    expected_calls = [call(project_id=project_id, suite_id=suite_id, limit=2, offset=i) for i in range(0, 4, 2)]
+    mock_api_client.cases.get_cases.assert_has_calls(expected_calls, any_order=False)
+    assert subject_adapter.stats.get_cases == 2
+    assert subject_adapter.stats.total == 2
+
+
+def test_get_case_fields_returns_correct_instance_type(subject_adapter, mock_api_client):
+    actual = subject_adapter.get_case_fields()
+    assert len(actual) > 0
+    for field_item in actual:
+        assert isinstance(field_item, TestRailCaseField)
+        assert field_item.description is not None
+    assert subject_adapter.stats.get_case_fields == 1
+    assert subject_adapter.stats.total == 1
+
+
+def test_get_case_types_returns_correct_instance_type(subject_adapter, mock_api_client):
+    actual = subject_adapter.get_case_types()
+    assert len(actual) == 2
+    assert isinstance(actual, list)
+    for case_type in actual:
+        assert isinstance(case_type, TestRailCaseType)
+    assert subject_adapter.stats.get_case_types == 1
+    assert subject_adapter.stats.total == 1
+
+
+@pytest.mark.parametrize("soft", [True, False])
+def test_delete_section_deletes_a_single_section(subject_adapter, mock_api_client, suite_fixture, soft):
+    section = list(suite_fixture.sections.values())[0]
+    subject_adapter.delete_section(section=section, soft=soft)
+    mock_api_client.sections.delete_section.assert_called_once_with(section_id=section.section_id, soft=int(soft))
+    assert subject_adapter.stats.delete_section == 1
+    assert subject_adapter.stats.total == 1
+    if soft:
+        assert section.section_id in suite_fixture.sections
+    else:
+        assert section.section_id not in suite_fixture.sections
+
+
+@pytest.mark.parametrize("soft", [True, False])
+def test_delete_case_deletes_a_single_case(subject_adapter, mock_api_client, suite_fixture, soft):
+    case = list(suite_fixture.cases.values())[0]
+    subject_adapter.delete_case(case=case, soft=soft)
+    mock_api_client.cases.delete_case.assert_called_once_with(case_id=case.case_id, soft=int(soft))
+    assert subject_adapter.stats.delete_case == 1
+    assert subject_adapter.stats.total == 1
+    if soft:
+        assert case.case_id in suite_fixture.cases
+    else:
+        assert case.case_id not in suite_fixture.cases
+
+
+def test_move_section_moves_a_single_section_to_top(subject_adapter, mock_api_client, suite_fixture):
+    new_parent = None
+    top_section = list(suite_fixture.direct_sections.values())[0]
+    bottom_section = list(top_section.sections.values())[0]
+    assert bottom_section.parent is not None
+    subject_adapter.move_section(section=bottom_section, new_parent=new_parent)
+    assert bottom_section.parent is None
+    mock_api_client.sections.move_section.assert_called_once_with(section_id=bottom_section.section_id, parent_id=None)
+
+
+def test_move_section_moves_a_single_section_to_new_section(subject_adapter, mock_api_client, suite_fixture):
+    top_section = list(suite_fixture.direct_sections.values())[0]
+    bottom_section = list(top_section.sections.values())[0]
+    new_parent = TestRailSection.from_data(get_section_response())
+    new_parent.suite_id = suite_fixture.suite_id
+    new_parent.link(suite_fixture)
+    assert bottom_section.parent is top_section
+    subject_adapter.move_section(section=bottom_section, new_parent=new_parent)
+
+    assert bottom_section.parent is not top_section
+    assert bottom_section.parent is new_parent
+    mock_api_client.sections.move_section.assert_called_once_with(section_id=bottom_section.section_id,
+                                                                  parent_id=new_parent.section_id)
+
+
+def test_create_new_section_for_path(subject_adapter):
+    suite = TestRailSuite.from_data(get_suite_response())
+    new_section = TestRailSection.from_data(get_section_response())
+    parent_section = TestRailSection.from_data(get_section_response())
+
+    # Set up ID (foreign key) links without explicitly linking objects
+    new_section.suite_id = suite.suite_id
+    parent_section.suite_id = suite.suite_id
+    new_section.parent_id = parent_section.section_id
+
+    with patch.object(suite, 'section_for_path', return_value=parent_section) as section_for_path_mock:
+        with patch.object(subject_adapter, 'add_section', return_value=new_section) as add_section_patch:
+            actual = subject_adapter.create_new_section_for_path(suite=suite, path='path/to/new/section')
+
+    assert isinstance(actual, TestRailSection)
+    assert actual is new_section
+    assert actual.suite is suite
+    assert actual.parent is not None
+    assert actual.parent is parent_section
+    add_section_patch.assert_called_once_with(
+        name="section",
+        project_id=suite.project_id,
+        suite_id=suite.suite_id,
+        parent_id=parent_section.section_id
+    )
+    section_for_path_mock.assert_called_once_with('path/to/new')

--- a/tests/test_builder.py
+++ b/tests/test_builder.py
@@ -1,281 +1,65 @@
-from typing import Generator
-from unittest.mock import call, patch
-
-from testrail_api import TestRailAPI
-
-from testrail_data_model.builder import TestRailAPIObjectBuilder
-from testrail_data_model.model import (
-    TestRailProject,
-    TestRailSuite,
-    TestRailSection,
-    TestRailCase,
-    TestRailCaseField,
-    TestRailCaseType
-)
-
 from .conftest import *
 
-# Prevent pytest from discovering these classes
-for item in [
-    TestRailAPI,
-    TestRailAPIObjectBuilder,
-    TestRailAPIRequestStats,
-    TestRailProject,
-    TestRailSuite,
-    TestRailSection,
-    TestRailCase,
-    TestRailCaseField,
-    TestRailCaseFieldType,
-    TestRailCaseType
-]:
-    item.__test__ = False
 
-
-def test_get_project_returns_correct_instance_type(mock_api_client, stats_fixture):
-    project_id = FIELD("integer_number", start=1, end=1000)
-    subject = TestRailAPIObjectBuilder(api_client=mock_api_client, stats=stats_fixture)
-    actual = subject.get_project(project_id=project_id)
-    mock_api_client.projects.get_project.assert_called_once_with(project_id=project_id)
-    assert isinstance(actual, TestRailProject)
-    assert actual.announcement is not None
-    assert subject.stats.get_project == 1
-    assert subject.stats.total == 1
-
-
-def test_get_projects_returns_generator_of_project_instances(mock_api_client, stats_fixture):
-    subject = TestRailAPIObjectBuilder(api_client=mock_api_client, stats=stats_fixture)
-    actual = subject.get_projects(limit=1)
-    assert isinstance(actual, Generator)
-    for project in actual:
-        assert isinstance(project, TestRailProject)
-        assert project.announcement is not None
-    expected_calls = [call(limit=1, offset=i) for i in range(4)]
-    mock_api_client.projects.get_projects.assert_has_calls(calls=expected_calls, any_order=False)
-    assert subject.stats.get_projects == 4
-    assert subject.stats.total == 4
-
-
-def test_get_suite_returns_correct_instance_type(mock_api_client, stats_fixture):
-    subject = TestRailAPIObjectBuilder(api_client=mock_api_client, stats=stats_fixture)
-    suite_id = FIELD("integer_number", start=1, end=1000)
-    actual = subject.get_suite(suite_id=suite_id)
-    mock_api_client.suites.get_suite.assert_called_once_with(suite_id=suite_id)
-    assert isinstance(actual, TestRailSuite)
-    assert actual.description is not None
-    assert subject.stats.get_suite == 1
-    assert subject.stats.total == 1
-
-
-def test_get_suites_returns_list_of_suite_instances(mock_api_client, stats_fixture):
-    subject = TestRailAPIObjectBuilder(api_client=mock_api_client, stats=stats_fixture)
-    project_id = FIELD("integer_number", start=1, end=1000)
-    actual = subject.get_suites(project_id=project_id)
-    assert len(actual) > 0
-    for suite in actual:
-        assert isinstance(suite, TestRailSuite)
-        assert suite.description is not None
-    mock_api_client.suites.get_suites.assert_called_once_with(project_id=project_id)
-    assert subject.stats.get_suites == 1
-    assert subject.stats.total == 1
-
-
-def test_get_sections_returns_correct_instance_type(mock_api_client, stats_fixture):
-    subject = TestRailAPIObjectBuilder(api_client=mock_api_client, stats=stats_fixture)
-    section_id = FIELD("integer_number", start=1, end=1000)
-    actual = subject.get_section(section_id=section_id)
-    mock_api_client.sections.get_section.assert_called_once_with(section_id=section_id)
-    assert isinstance(actual, TestRailSection)
-    assert actual.description is not None
-    assert subject.stats.get_section == 1
-    assert subject.stats.total == 1
-
-
-def test_get_section_returns_generator_of_sections(mock_api_client, stats_fixture):
-    subject = TestRailAPIObjectBuilder(api_client=mock_api_client, stats=stats_fixture)
-    project_id = FIELD("integer_number", start=1, end=1000)
-    suite_id = FIELD("integer_number", start=1, end=1000)
-    actual = subject.get_sections(project_id=project_id, suite_id=suite_id, limit=1, offset=0)
-    for section in actual:
-        assert isinstance(section, TestRailSection)
-        assert section.description is not None
-    expected_calls = [call(limit=1, offset=i, project_id=project_id, suite_id=suite_id) for i in range(4)]
-    mock_api_client.sections.get_sections.assert_has_calls(calls=expected_calls, any_order=False)
-    assert subject.stats.total == 4
-    assert subject.stats.get_sections == 4
-
-
-def test_add_section_returns_correct_instance_type(mock_api_client, stats_fixture):
-    subject = TestRailAPIObjectBuilder(api_client=mock_api_client, stats=stats_fixture)
-    project_id = FIELD("integer_number", start=1, end=1000)
-    suite_id = FIELD("integer_number", start=1, end=1000)
-    name = FIELD("word")
-    description = FIELD("text")
-    parent_id = FIELD("integer_number", start=1, end=1000)
-    actual = subject.add_section(
-        project_id=project_id,
-        suite_id=suite_id,
-        name=name,
-        description=description,
-        parent_id=parent_id
-    )
-    mock_api_client.sections.add_section.assert_called_once_with(
-        project_id=project_id,
-        suite_id=suite_id,
-        name=name,
-        description=description,
-        parent_id=parent_id
-    )
-    assert isinstance(actual, TestRailSection)
-    assert actual.description is not None
-    assert subject.stats.add_section == 1
-    assert subject.stats.total == 1
-
-
-def test_get_case_returns_correct_instance_type(mock_api_client, stats_fixture):
-    case_id = FIELD("integer_number", start=1, end=1000)
-    subject = TestRailAPIObjectBuilder(api_client=mock_api_client, stats=stats_fixture)
-    actual = subject.get_case(case_id=case_id)
-    assert isinstance(actual, TestRailCase)
-    assert len(actual.steps_separated) == 1
-    assert actual.steps_separated[0]["content"] is not None
-    assert subject.stats.get_case == 1
-    assert subject.stats.total == 1
-    mock_api_client.cases.get_case.assert_called_once_with(case_id=case_id)
-
-
-def test_add_case_returns_correct_instance_type(mock_api_client, stats_fixture):
-    section_id = FIELD("integer_number", start=1, end=1000)
-    title = FIELD("title")
-    subject = TestRailAPIObjectBuilder(api_client=mock_api_client, stats=stats_fixture)
-    actual = subject.add_case(section_id=section_id, title=title)
-    assert isinstance(actual, TestRailCase)
-    assert len(actual.steps_separated) == 1
-    assert actual.steps_separated[0]["content"] is not None
-    assert subject.stats.add_case == 1
-    assert subject.stats.total == 1
-    mock_api_client.cases.add_case.assert_called_once_with(section_id=section_id, title=title)
-
-
-def test_update_case_returns_correct_instance_type(mock_api_client, stats_fixture):
-    case_id = FIELD("integer_number", start=1, end=1000)
-    section_id = FIELD("integer_number", start=1, end=1000)
-    title = FIELD("title")
-    subject = TestRailAPIObjectBuilder(api_client=mock_api_client, stats=stats_fixture)
-    start_case = subject.get_case(case_id=case_id)
-    actual = subject.update_case(case=start_case, title=title, section_id=section_id)
-    assert isinstance(actual, TestRailCase)
-    assert len(actual.steps_separated) == 1
-    assert actual.steps_separated[0]["content"] is not None
-    assert subject.stats.update_case == 1
-    assert subject.stats.total == 2
-    mock_api_client.cases.update_case.assert_called_once_with(
-        case_id=start_case.case_id,
-        title=title,
-        section_id=section_id
-    )
-
-
-def test_get_cases_returns_generator_of_cases(mock_api_client, stats_fixture):
-    subject = TestRailAPIObjectBuilder(api_client=mock_api_client, stats=stats_fixture)
-    project_id = FIELD("integer_number", start=1, end=1000)
-    actual = subject.get_cases(project_id=project_id, limit=2, offset=0)
-    assert isinstance(actual, Generator)
-    for case in actual:
-        assert isinstance(case, TestRailCase)
-        assert len(case.steps_separated) == 1
-        assert case.steps_separated[0]["content"] is not None
-    expected_calls = [call(project_id=project_id, limit=2, offset=i) for i in range(0, 4, 2)]
-    mock_api_client.cases.get_cases.assert_has_calls(expected_calls, any_order=False)
-    assert subject.stats.get_cases == 2
-    assert subject.stats.total == 2
-
-
-def test_get_cases_with_suite_returns_generator_of_cases(mock_api_client, stats_fixture):
-    subject = TestRailAPIObjectBuilder(api_client=mock_api_client, stats=stats_fixture)
-    project_id = FIELD("integer_number", start=1, end=1000)
-    suite_id = FIELD("integer_number", start=1, end=1000)
-    actual = subject.get_cases(project_id=project_id, suite_id=suite_id, limit=2, offset=0)
-    assert isinstance(actual, Generator)
-    for case in actual:
-        assert isinstance(case, TestRailCase)
-        assert len(case.steps_separated) == 1
-        assert case.steps_separated[0]["content"] is not None
-    expected_calls = [call(project_id=project_id, suite_id=suite_id, limit=2, offset=i) for i in range(0, 4, 2)]
-    mock_api_client.cases.get_cases.assert_has_calls(expected_calls, any_order=False)
-    assert subject.stats.get_cases == 2
-    assert subject.stats.total == 2
-
-
-def test_get_case_fields_returns_correct_instance_type(mock_api_client, stats_fixture):
-    subject = TestRailAPIObjectBuilder(api_client=mock_api_client, stats=stats_fixture)
-    actual = subject.get_case_fields()
-    assert len(actual) > 0
-    for field_item in actual:
-        assert isinstance(field_item, TestRailCaseField)
-        assert field_item.description is not None
-    assert subject.stats.get_case_fields == 1
-    assert subject.stats.total == 1
-
-
-def test_create_new_section_for_path(mock_api_client, stats_fixture):
-    subject = TestRailAPIObjectBuilder(api_client=mock_api_client, stats=stats_fixture)
-    suite = TestRailSuite.from_data(get_suite_response())
-    new_section = TestRailSection.from_data(get_section_response())
-    parent_section = TestRailSection.from_data(get_section_response())
-
-    # Set up ID (foreign key) links without explicitly linking objects
-    new_section.suite_id = suite.suite_id
-    parent_section.suite_id = suite.suite_id
-    new_section.parent_id = parent_section.section_id
-
-    with patch.object(suite, 'section_for_path', return_value=parent_section) as section_for_path_mock:
-        with patch.object(subject, 'add_section', return_value=new_section) as add_section_patch:
-            actual = subject.create_new_section_for_path(suite=suite, path='path/to/new/section')
-    assert isinstance(actual, TestRailSection)
-    assert actual is new_section
-    assert actual.suite is suite
-    assert actual.parent is not None
-    assert actual.parent is parent_section
-    add_section_patch.assert_called_once_with(
-        name="section",
-        project_id=suite.project_id,
-        suite_id=suite.suite_id,
-        parent_id=parent_section.section_id
-    )
-    section_for_path_mock.assert_called_once_with('path/to/new')
-
-
-def test_build_suite_returns_suite_instance_with_links(mock_api_client, stats_fixture):
-    subject = TestRailAPIObjectBuilder(api_client=mock_api_client, stats=stats_fixture)
+@pytest.fixture()
+def mock_adapter():
     suite = TestRailSuite.from_data(get_suite_response())
     top_section = TestRailSection.from_data(get_section_response())
     bottom_section = TestRailSection.from_data(get_section_response())
     case = TestRailCase.from_data(get_case_response())
-
-    project_id = suite.project_id
     suite_id = suite.suite_id
 
     # Set up ID (foreign key) matching without explicitly linking
     top_section.suite_id = suite_id
     top_section.parent_id = None
     bottom_section.suite_id = suite_id
+    bottom_section.parent_id = top_section.section_id
     case.suite_id = suite_id
     case.section_id = bottom_section.section_id
-    bottom_section.parent_id = top_section.section_id
 
-    with patch.object(subject, 'get_cases', return_value=[case]):
-        with patch.object(subject, 'get_sections', return_value=[top_section, bottom_section]):
-            with patch.object(subject, 'get_suite', return_value=suite):
-                actual = subject.build_suite(project_id=project_id, suite_id=suite_id)
-    assert isinstance(actual, TestRailSuite)
-    assert actual is suite
+    return MagicMock(
+        get_cases=MagicMock(return_value=[case]),
+        get_sections=MagicMock(return_value=[top_section, bottom_section]),
+        get_suite=MagicMock(return_value=suite)
+    )
 
-    # Check the linking of the objects
+
+@pytest.fixture()
+def subject_builder(mock_adapter):
+    subject = TestRailAPIObjectBuilder(adapter=mock_adapter)
+    return subject
+
+
+def test_build_suite_returns_suite_instance_with_links(subject_builder):
+    project_id = 0
+    suite_id = 0
+    suite = subject_builder.build_suite(project_id=project_id, suite_id=suite_id)
+    assert isinstance(suite, TestRailSuite)
+
+    # Check links from TestRailSuite object
     assert len(suite.sections) == 2
     assert len(suite.cases) == 1
-    assert list(suite.direct_sections.values()) == [top_section]
-    assert list(suite.direct_cases.values()) == []
-    assert suite.cases[case.case_id] is case
+    assert len(suite.direct_cases) == 0
+
+    # Check links from top-most TestRailSection object
+    top_section = list(suite.direct_sections.values())[0]
+    assert len(top_section.sections) == 1
+    assert len(top_section.cases) == 0
+    assert top_section.suite is suite
+    assert top_section.parent is None
+
+    # Check links from bottom-most TestRailSection object
+    bottom_section = list(top_section.sections.values())[0]
+    assert bottom_section.parent is top_section
+    assert len(bottom_section.sections) == 0
+    assert len(bottom_section.cases) == 1
+
+    # Check links from the TestRailCase object
+    case = list(suite.cases.values())[0]
+    assert case.suite is suite
+    assert case.section is bottom_section
+
+    # Check section paths exist
     assert suite.all_section_paths == {
         top_section.section_id: top_section.path,
         bottom_section.section_id: bottom_section.path
@@ -283,20 +67,7 @@ def test_build_suite_returns_suite_instance_with_links(mock_api_client, stats_fi
     assert suite.section_for_path(top_section.path) is top_section
     assert suite.section_for_path(bottom_section.path) is bottom_section
     assert suite.section_for_path(bottom_section.path + "foobar") is None
-
-    assert top_section.suite is suite
-    assert top_section.parent is None
-    assert len(top_section.cases) == 0
-
-    assert bottom_section.suite is suite
-    assert bottom_section.parent is top_section
-    assert len(bottom_section.cases) == 1
-    assert bottom_section.cases[case.case_id] is case
     assert bottom_section.path == f"{top_section.name}/{bottom_section.name}"
-
-    assert case.case_id in suite.cases
-    assert case.suite is suite
-    assert case.section is bottom_section
     assert case.path == f"{top_section.name}/{bottom_section.name}"
 
     # Try unlinking
@@ -307,111 +78,3 @@ def test_build_suite_returns_suite_instance_with_links(mock_api_client, stats_fi
     assert len(suite.sections) == 0
     assert len(top_section.sections) == 0
     assert len(bottom_section.cases) == 0
-
-
-def test_section_suite_linking_fails_if_ids_unequal():
-    suite = TestRailSuite.from_data(get_suite_response())
-    section = TestRailSection.from_data(get_section_response())
-    section.suite_id = suite.suite_id + 1
-    with pytest.raises(ValueError) as exc_info:
-        section.link(suite=suite)
-    assert str(exc_info.value) == \
-           f"section.suite_id ({section.suite_id}) does not match suite.suite_id ({suite.suite_id})"
-
-
-def test_section_parent_linking_fails_if_ids_unequal():
-    suite = TestRailSuite.from_data(get_suite_response())
-    section = TestRailSection.from_data(get_section_response())
-    parent = TestRailSection.from_data(get_section_response())
-    section.suite_id = suite.suite_id
-    section.parent_id = parent.section_id + 1
-    with pytest.raises(ValueError) as exc_info:
-        section.link(suite=suite, parent=parent)
-    assert str(exc_info.value) == \
-           f"section.parent_id ({section.parent_id}) does not match parent.section_id ({parent.section_id})"
-
-
-def test_case_suite_linking_fails_if_ids_unequal():
-    suite = TestRailSuite.from_data(get_suite_response())
-    case = TestRailCase.from_data(get_case_response())
-    case.suite_id = suite.suite_id + 1
-    with pytest.raises(ValueError) as exc_info:
-        case.link(suite=suite)
-    assert str(exc_info.value) == \
-           f"case.suite_id ({case.suite_id}) does not match suite.suite_id ({suite.suite_id})"
-
-
-def test_case_section_linking_fails_if_ids_unequal():
-    suite = TestRailSuite.from_data(get_suite_response())
-    section = TestRailSection.from_data(get_section_response())
-    case = TestRailCase.from_data(get_case_response())
-    case.suite_id = suite.suite_id
-    case.section_id = section.section_id + 1
-    with pytest.raises(ValueError) as exc_info:
-        case.link(suite=suite, section=section)
-    assert str(exc_info.value) == \
-           f"case.section_id ({case.section_id}) does not match section.section_id ({section.section_id})"
-
-
-def test_case_section_linking_passes_with_no_section():
-    suite = TestRailSuite.from_data(get_suite_response())
-    section = None
-    case = TestRailCase.from_data(get_case_response())
-    case.suite_id = suite.suite_id
-    case.link(suite=suite, section=section)
-    assert case.suite is suite
-    assert case.section is None
-
-
-def test_case_get_custom_raises_exceptions():
-    case = TestRailCase.from_data(get_case_response())
-    with pytest.raises(ValueError) as value_error:
-        case.__getattr__('')
-    assert str(value_error.value) == "Attribute must be non-zero length"
-    with pytest.raises(AttributeError) as attr_error:
-        case.__getattr__('does_not_exist')
-    assert str(attr_error.value) == "TestRailCase instance has no custom field: 'custom_does_not_exist'"
-
-
-def test_case_to_dict_returns_original_api_response():
-    api_response = get_case_response()
-    case = TestRailCase.from_data(api_response)
-    assert case.to_dict() == api_response
-
-
-def test_get_case_types_returns_correct_instance_type(mock_api_client, stats_fixture):
-    subject = TestRailAPIObjectBuilder(api_client=mock_api_client, stats=stats_fixture)
-    actual = subject.get_case_types()
-    assert len(actual) == 2
-    assert isinstance(actual, list)
-    for case_type in actual:
-        assert isinstance(case_type, TestRailCaseType)
-    assert subject.stats.get_case_types == 1
-    assert subject.stats.total == 1
-
-
-def test_unlink_case_disassociates_from_suite_and_section():
-    suite = TestRailSuite.from_data(get_suite_response())
-    case = TestRailCase.from_data(get_case_response())
-    section = TestRailSection.from_data(get_section_response())
-    case.suite_id = suite.suite_id
-    section.suite_id = suite.suite_id
-    case.section_id = section.section_id
-    section.link(suite=suite, parent=None)
-    case.link(suite=suite, section=section)
-    assert case.case_id in suite.cases
-    assert case.case_id in section.cases
-    assert case.section_id in suite.sections
-    assert case.suite is suite
-    assert case.section is section
-    case.unlink()
-    assert case.case_id not in suite.cases
-    assert case.suite is None
-    assert case.section is None
-
-
-def test_unlink_case_on_unlinked_case_makes_no_change():
-    case = TestRailCase.from_data(get_case_response())
-    case.unlink()
-    assert case.suite is None
-    assert case.section is None

--- a/tests/test_deletion.py
+++ b/tests/test_deletion.py
@@ -1,32 +1,13 @@
 from typing import Generator
-from unittest.mock import call
+
+from testrail_data_model.deletion import DeletionHandler, MarkForDeletionHandler, deletion_handler_factory
 
 from .conftest import *
 
-from testrail_data_model.deletion import DeletionHandler, MarkForDeletionHandler, deletion_handler_factory
-from testrail_data_model.model import TestRailSuite, TestRailCase, TestRailSection
 
-
-@pytest.fixture
-def suite_fixture():
-    suite = TestRailSuite.from_data(get_suite_response())
-    section1 = TestRailSection.from_data(get_section_response())
-    section2 = TestRailSection.from_data(get_section_response())
-    case1 = TestRailCase.from_data(get_case_response())
-    case2 = TestRailCase.from_data(get_case_response())
-    section2.suite_id = suite.suite_id
-    section2.parent_id = section1.section_id
-    section1.suite_id = suite.suite_id
-    section1.parent_id = None
-    case1.suite_id = suite.suite_id
-    case1.section_id = section2.section_id
-    case2.suite_id = suite.suite_id
-    case2.section_id = section2.section_id
-    case1.link(suite=suite, section=section2)
-    case2.link(suite=suite, section=section2)
-    section1.link(suite=suite, parent=None)
-    section2.link(suite=suite, parent=section1)
-    return suite
+@pytest.fixture()
+def mock_adapter():
+    return MagicMock()
 
 
 @pytest.fixture
@@ -47,153 +28,124 @@ def suite_fixture_with_deletion_marking(suite_fixture):
 
 
 @pytest.mark.parametrize("soft", [True, False])
-def test_real_handler_deletes_a_single_case(mock_api_client, stats_fixture, suite_fixture, soft):
-    subject = DeletionHandler(suite=suite_fixture, api_client=mock_api_client, stats=stats_fixture, soft=soft)
+def test_handler_deletes_a_single_case(mock_adapter, suite_fixture, soft):
+    subject = DeletionHandler(suite=suite_fixture, adapter=mock_adapter, soft=soft)
     case = list(suite_fixture.cases.values())[0]
     subject.delete_case(case=case)
-    mock_api_client.cases.delete_case.assert_called_once_with(case_id=case.case_id, soft=int(soft))
-    assert subject.stats.delete_case == 1
-    assert subject.stats.total == 1
-    if soft:
-        assert case.case_id in suite_fixture.cases
-    else:
-        assert case.case_id not in suite_fixture.cases
+    mock_adapter.delete_case.assert_called_once_with(case=case, soft=soft)
 
 
 @pytest.mark.parametrize("soft", [True, False])
-def test_real_handler_deletes_a_single_section(mock_api_client, stats_fixture, suite_fixture, soft):
-    subject = DeletionHandler(suite=suite_fixture, api_client=mock_api_client, stats=stats_fixture, soft=soft)
+def test_handler_deletes_a_single_section(mock_adapter, suite_fixture, soft):
+    subject = DeletionHandler(suite=suite_fixture, adapter=mock_adapter, soft=soft)
     section = list(suite_fixture.sections.values())[0]
     subject.delete_section(section=section)
-    mock_api_client.sections.delete_section.assert_called_once_with(section_id=section.section_id, soft=int(soft))
-    assert subject.stats.delete_section == 1
-    assert subject.stats.total == 1
-    if soft:
-        assert section.section_id in suite_fixture.sections
-    else:
-        assert section.section_id not in suite_fixture.sections
+    mock_adapter.delete_section.assert_called_once_with(section=section, soft=soft)
 
 
 @pytest.mark.parametrize("soft", [True, False])
-def test_real_handler_deletes_multiple_cases(mock_api_client, stats_fixture, suite_fixture, soft):
-    subject = DeletionHandler(suite=suite_fixture, api_client=mock_api_client, stats=stats_fixture, soft=soft)
+def test_handler_deletes_multiple_cases(mock_adapter, suite_fixture, soft):
+    subject = DeletionHandler(suite=suite_fixture, adapter=mock_adapter, soft=soft)
     cases_to_delete = list(suite_fixture.cases.values())
     actual = subject.delete_cases(cases_to_delete)
     assert isinstance(actual, Generator)
     for _ in actual:
         continue
-    expected_calls = [call(case_id=case.case_id, soft=int(soft)) for case in cases_to_delete]
-    mock_api_client.cases.delete_case.assert_has_calls(calls=expected_calls, any_order=True)
-    remaining_case_count = 2 if soft else 0
-    assert len(suite_fixture.cases) == remaining_case_count
-    assert stats_fixture.delete_case == 2
-    assert stats_fixture.total == 2
+    expected_calls = [call(case=case, soft=soft) for case in cases_to_delete]
+    mock_adapter.delete_case.assert_has_calls(calls=expected_calls, any_order=False)
 
 
 @pytest.mark.parametrize("soft", [True, False])
-def test_real_handler_deletes_multiple_sections(mock_api_client, stats_fixture, suite_fixture, soft):
-    subject = DeletionHandler(suite=suite_fixture, api_client=mock_api_client, stats=stats_fixture, soft=soft)
+def test_handler_deletes_multiple_sections(mock_adapter, suite_fixture, soft):
+    subject = DeletionHandler(suite=suite_fixture, adapter=mock_adapter, soft=soft)
     sections_to_delete = list(suite_fixture.sections.values())
     actual = subject.delete_sections(sections_to_delete)
     assert isinstance(actual, Generator)
     for _ in actual:
         continue
-    expected_calls = [call(section_id=section.section_id, soft=int(soft)) for section in sections_to_delete]
-    mock_api_client.sections.delete_section.assert_has_calls(calls=expected_calls, any_order=True)
-    remaining_section_count = 2 if soft else 0
-    assert len(suite_fixture.sections) == remaining_section_count
-    assert stats_fixture.delete_section == 2
-    assert stats_fixture.total == 2
+    expected_calls = [call(section=section, soft=soft) for section in sections_to_delete]
+    mock_adapter.delete_section.assert_has_calls(calls=expected_calls, any_order=False)
 
 
-def test_mark_case_for_deletion_handles_single_case(mock_api_client, stats_fixture, suite_fixture_with_deletion_marking):
+def test_mark_case_for_deletion_handles_single_case(mock_adapter, suite_fixture_with_deletion_marking):
     suite = suite_fixture_with_deletion_marking
     new_case = TestRailCase.from_data(get_case_response())
     new_case.suite_id = suite.suite_id
-    builder = MagicMock(
-        update_case=MagicMock(return_value=new_case)
-    )
-    subject = MarkForDeletionHandler(suite=suite, builder=builder, api_client=mock_api_client)
+    subject = MarkForDeletionHandler(suite=suite, adapter=mock_adapter)
     new_section_id = subject.to_be_deleted_sections[0].section_id
     new_case.section_id = new_section_id
     case = list(suite.cases.values())[0]
+    mock_adapter.update_case = MagicMock(return_value=new_case)
     actual = subject.delete_case(case=case)
     assert actual is new_case
-    builder.update_case.assert_called_once_with(case=case, section_id=new_section_id)
+    mock_adapter.update_case.assert_called_once_with(case=case, section_id=new_section_id)
 
 
-def test_mark_section_for_deletion_handles_single_section(mock_api_client, stats_fixture,
-                                                          suite_fixture_with_deletion_marking):
+def test_mark_section_for_deletion_handles_single_section(mock_adapter, suite_fixture_with_deletion_marking):
     suite = suite_fixture_with_deletion_marking
-    subject = MarkForDeletionHandler(suite=suite, builder=MagicMock(), api_client=mock_api_client)
-    new_section_id = subject.to_be_deleted_sections[1].section_id
+    subject = MarkForDeletionHandler(suite=suite, adapter=mock_adapter)
+    _, new_parent = subject.to_be_deleted_sections
     section = None
     for _section in suite.direct_sections.values():
         if not _section.path.startswith('__to_be_deleted__'):
             section = _section
             break
     assert section is not None
+
+    mock_adapter.move_section = MagicMock(return_value=section)
     actual = subject.delete_section(section=section)
     assert actual is section
-    mock_api_client.sections.move_section.assert_called_once_with(
-        section_id=section.section_id,
-        parent_id=new_section_id
-    )
+    mock_adapter.move_section.assert_called_once_with(section=section, new_parent=new_parent)
 
 
-def test_mark_cases_for_deletion_handles_multiple_cases(mock_api_client, stats_fixture,
-                                                        suite_fixture_with_deletion_marking):
+def test_mark_cases_for_deletion_handles_multiple_cases(mock_adapter, suite_fixture_with_deletion_marking):
     suite = suite_fixture_with_deletion_marking
     already_marked = TestRailCase.from_data(get_case_response())
     already_marked.suite_id = suite.suite_id
     new_case = TestRailCase.from_data(get_case_response())
     new_case.suite_id = suite.suite_id
-    builder = MagicMock(
-        update_case=MagicMock(side_effect=[new_case, already_marked])
-    )
-    subject = MarkForDeletionHandler(suite=suite, builder=builder, api_client=mock_api_client)
-    new_section_id = subject.to_be_deleted_sections[0].section_id
+    subject = MarkForDeletionHandler(suite=suite, adapter=mock_adapter)
+    to_be_deleted_section = subject.to_be_deleted_sections[0]
+    new_section_id = to_be_deleted_section.section_id
     already_marked.section_id = new_section_id
     new_case.section_id = new_section_id
-    already_marked.link(suite=suite, section=subject.to_be_deleted_sections[0])
+    already_marked.link(suite=suite, section=to_be_deleted_section)
     cases_to_delete = [list(suite.cases.values())[0], already_marked]
+    mock_adapter.update_case = MagicMock(return_value=new_case)
     actual = subject.delete_cases(cases_to_delete)
     assert isinstance(actual, Generator)
     results = [res for res in actual]
-    builder.update_case.assert_called_once_with(case=cases_to_delete[0], section_id=new_section_id)
+    mock_adapter.update_case.assert_called_once_with(case=cases_to_delete[0], section_id=new_section_id)
     assert len(results) == 2
     assert results == [new_case, already_marked]
 
 
-def test_mark_sections_for_deletion_handles_multiple_sections(mock_api_client, stats_fixture,
-                                                              suite_fixture_with_deletion_marking):
+def test_mark_sections_for_deletion_handles_multiple_sections(mock_adapter, suite_fixture_with_deletion_marking):
     suite = suite_fixture_with_deletion_marking
-    subject = MarkForDeletionHandler(suite=suite, builder=MagicMock(), api_client=mock_api_client)
-    new_section_id = subject.to_be_deleted_sections[1].section_id
+    subject = MarkForDeletionHandler(suite=suite, adapter=mock_adapter)
+    _, new_parent = subject.to_be_deleted_sections
     all_sections = list(suite.sections.values())
     sections_to_mark = sorted(
         [section for section in all_sections if not section.path.startswith('__to_be_deleted__')],
         key=lambda x: x.path,
         reverse=True
     )
-    expected_calls = [call(section_id=section.section_id, parent_id=new_section_id) for section in sections_to_mark]
-    for section in sections_to_mark:
-        print(section.path)
+    expected_calls = [call(section=section, new_parent=new_parent) for section in sections_to_mark]
     actual = subject.delete_sections(sections=(sections_to_mark + list(subject.to_be_deleted_sections)))
     assert isinstance(actual, Generator)
     results = [res for res in actual]
     assert len(results) > 2
-    mock_api_client.sections.move_section.assert_has_calls(calls=expected_calls, any_order=False)
+    mock_adapter.move_section.assert_has_calls(calls=expected_calls, any_order=False)
 
 
 @pytest.mark.parametrize("settings", [{"mark_for_deletion": True}, {"mark_for_deletion": False}, {}])
-def test_handler_factory_returns_correct_instance(suite_fixture, mock_api_client, settings):
-    actual = deletion_handler_factory(suite=suite_fixture, api_client=mock_api_client, **settings)
+def test_handler_factory_returns_correct_instance(suite_fixture, mock_adapter, settings):
+    actual = deletion_handler_factory(suite=suite_fixture, adapter=mock_adapter, **settings)
     expected_type = MarkForDeletionHandler if settings.get("mark_for_deletion", True) else DeletionHandler
     assert isinstance(actual, expected_type)
 
 
-def test_mark_for_deletion_special_sections_are_created_if_not_found(suite_fixture, mock_api_client):
+def test_mark_for_deletion_special_sections_are_created_if_not_found(mock_adapter, suite_fixture):
     suite = suite_fixture
     to_be_deleted_section_name = FIELD('word')
     to_be_deleted_section = TestRailSection.from_data(get_section_response())
@@ -204,11 +156,11 @@ def test_mark_for_deletion_special_sections_are_created_if_not_found(suite_fixtu
     to_be_deleted_section_section.suite_id = suite_fixture.suite_id
     to_be_deleted_section_section.parent_id = to_be_deleted_section.section_id
     to_be_deleted_section_section.name = "sections"
-    builder = MagicMock(
-        create_new_section_for_path=MagicMock(side_effect=[to_be_deleted_section, to_be_deleted_section_section])
+    mock_adapter.create_new_section_for_path = MagicMock(
+        side_effect=[to_be_deleted_section, to_be_deleted_section_section]
     )
-    subject = MarkForDeletionHandler(suite=suite, builder=builder, api_client=mock_api_client,
+    subject = MarkForDeletionHandler(suite=suite, adapter=mock_adapter,
                                      to_be_deleted_section_name=to_be_deleted_section_name)
     expected_calls = [call(suite, to_be_deleted_section_name), call(suite, to_be_deleted_section_name + "/sections")]
     assert subject.to_be_deleted_sections == (to_be_deleted_section, to_be_deleted_section_section)
-    builder.create_new_section_for_path.assert_has_calls(calls=expected_calls, any_order=False)
+    mock_adapter.create_new_section_for_path.assert_has_calls(calls=expected_calls, any_order=False)

--- a/tests/test_model.py
+++ b/tests/test_model.py
@@ -1,0 +1,111 @@
+from .conftest import *
+
+
+def test_section_suite_linking_fails_if_ids_unequal():
+    suite = TestRailSuite.from_data(get_suite_response())
+    section = TestRailSection.from_data(get_section_response())
+    section.suite_id = suite.suite_id + 1
+    with pytest.raises(ValueError) as exc_info:
+        section.link(suite=suite)
+    assert str(exc_info.value) == \
+           f"section.suite_id ({section.suite_id}) does not match suite.suite_id ({suite.suite_id})"
+
+
+def test_section_parent_linking_fails_if_ids_unequal():
+    suite = TestRailSuite.from_data(get_suite_response())
+    section = TestRailSection.from_data(get_section_response())
+    parent = TestRailSection.from_data(get_section_response())
+    section.suite_id = suite.suite_id
+    section.parent_id = parent.section_id + 1
+    with pytest.raises(ValueError) as exc_info:
+        section.link(suite=suite, parent=parent)
+    assert str(exc_info.value) == \
+           f"section.parent_id ({section.parent_id}) does not match parent.section_id ({parent.section_id})"
+
+
+def test_case_suite_linking_fails_if_ids_unequal():
+    suite = TestRailSuite.from_data(get_suite_response())
+    case = TestRailCase.from_data(get_case_response())
+    case.suite_id = suite.suite_id + 1
+    with pytest.raises(ValueError) as exc_info:
+        case.link(suite=suite)
+    assert str(exc_info.value) == \
+           f"case.suite_id ({case.suite_id}) does not match suite.suite_id ({suite.suite_id})"
+
+
+def test_case_section_linking_fails_if_ids_unequal():
+    suite = TestRailSuite.from_data(get_suite_response())
+    section = TestRailSection.from_data(get_section_response())
+    case = TestRailCase.from_data(get_case_response())
+    case.suite_id = suite.suite_id
+    case.section_id = section.section_id + 1
+    with pytest.raises(ValueError) as exc_info:
+        case.link(suite=suite, section=section)
+    assert str(exc_info.value) == \
+           f"case.section_id ({case.section_id}) does not match section.section_id ({section.section_id})"
+
+
+def test_case_section_linking_passes_with_no_section():
+    suite = TestRailSuite.from_data(get_suite_response())
+    section = None
+    case = TestRailCase.from_data(get_case_response())
+    case.suite_id = suite.suite_id
+    case.link(suite=suite, section=section)
+    assert case.suite is suite
+    assert case.section is None
+
+
+def test_case_get_custom_raises_exceptions():
+    case = TestRailCase.from_data(get_case_response())
+    with pytest.raises(ValueError) as value_error:
+        case.__getattr__('')
+    assert str(value_error.value) == "Attribute must be non-zero length"
+    with pytest.raises(AttributeError) as attr_error:
+        case.__getattr__('does_not_exist')
+    assert str(attr_error.value) == "TestRailCase instance has no custom field: 'custom_does_not_exist'"
+
+
+def test_case_to_dict_returns_original_api_response():
+    api_response = get_case_response()
+    case = TestRailCase.from_data(api_response)
+    assert case.to_dict() == api_response
+
+
+def test_unlink_case_disassociates_from_suite_and_section():
+    suite = TestRailSuite.from_data(get_suite_response())
+    case = TestRailCase.from_data(get_case_response())
+    section = TestRailSection.from_data(get_section_response())
+    case.suite_id = suite.suite_id
+    section.suite_id = suite.suite_id
+    case.section_id = section.section_id
+    section.link(suite=suite, parent=None)
+    case.link(suite=suite, section=section)
+    assert case.case_id in suite.cases
+    assert case.case_id in section.cases
+    assert case.section_id in suite.sections
+    assert case.suite is suite
+    assert case.section is section
+    case.unlink()
+    assert case.case_id not in suite.cases
+    assert case.suite is None
+    assert case.section is None
+
+
+def test_unlink_on_unlinked_case_makes_no_change():
+    case = TestRailCase.from_data(get_case_response())
+    assert case.suite is None
+    assert case.section is None
+    case.unlink()
+    assert case.suite is None
+    assert case.section is None
+
+
+def test_unlink_on_unlinked_section_makes_no_change():
+    section = TestRailSection.from_data(get_section_response())
+    assert section.suite is None
+    assert section.parent is None
+    assert len(section.cases) == 0
+    section.unlink()
+    assert section.suite is None
+    assert section.parent is None
+    assert len(section.cases) == 0


### PR DESCRIPTION
This has a few benefits:
* Simplifies the dependency hierarchy
* Hides the TestRailRequestStats exclusively behind the TestRailAPIAdapter
* Allows the TestRailAPIObjectBuilder to focus on building more complex object structures
* TestRailAPIAdapter performs the deletion, allowing the DeletionHandlers to better obscure the implementation